### PR TITLE
Convert the fragment shader to also use a vertex shader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import "./App.css";
 import { ShaderBackground } from "./components/ShaderBackground/ShaderBackground.tsx";
 import shaderString from "@/shaders/shader.frag?raw";
+import vertexShaderString from "@/shaders/shader.vert?raw";
 
 const App = () => {
   return (
     <div className="p-home">
-      <ShaderBackground fragShader={shaderString} />
+      <ShaderBackground fragShader={shaderString} vertShader={vertexShaderString} />
       <h1>welcome to songskip</h1>
     </div>
   );

--- a/src/components/ShaderBackground/ShaderBackground.tsx
+++ b/src/components/ShaderBackground/ShaderBackground.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from "react";
-export const ShaderBackground = ({ fragShader }: { fragShader: string }) => {
+export const ShaderBackground = ({ fragShader, vertShader }: { fragShader: string, vertShader: string }) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -11,12 +11,7 @@ export const ShaderBackground = ({ fragShader }: { fragShader: string }) => {
       return;
     }
 
-    const vertexShaderSource = `#version 300 es
-    in vec4 aVertexPosition;
-    void main() {
-      gl_Position = aVertexPosition;
-    }
-  `;
+    const vertexShaderSource = vertShader;
     const fragmentShaderSource = `#version 300 es
     precision mediump float;
     uniform float iTime;

--- a/src/shaders/shader.vert
+++ b/src/shaders/shader.vert
@@ -1,0 +1,7 @@
+#version 300 es
+
+in vec4 aVertexPosition;
+
+void main() {
+  gl_Position = aVertexPosition;
+}


### PR DESCRIPTION
Add support for vertex shader in ShaderBackground component.

* Modify `ShaderBackground` component in `src/components/ShaderBackground/ShaderBackground.tsx` to accept a `vertShader` prop and use it for creating the vertex shader.
* Update `App` component in `src/App.tsx` to import the vertex shader and pass it to `ShaderBackground` as the `vertShader` prop.
* Add new file `src/shaders/shader.vert` with the vertex shader source code.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shanecranor/songskip/pull/2?shareId=02eeb136-e1d2-4845-a6d7-48167d999ffd).