### PR TITLE
Determine the file type instead of assuming JSON to handle the full spotify data archive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@legendapp/state": "^3.0.0-beta.19",
         "arquero": "^7.2.0",
+        "fflate": "^0.8.2",
         "prettier": "^3.4.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -2089,6 +2090,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@legendapp/state": "^3.0.0-beta.19",
     "arquero": "^7.2.0",
+    "fflate": "^0.8.2",
     "prettier": "^3.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/components/DataUpload/DataUpload.tsx
+++ b/src/components/DataUpload/DataUpload.tsx
@@ -1,66 +1,71 @@
 import { ChangeEvent, useRef } from "react";
 import { useObservable, observer } from "@legendapp/state/react";
 import "./DataUpload.css";
-import { fileContent$ } from "@/state";
+import { fileContent$, uiState$, setError, resetUiState } from "@/state";
 import { processData } from "@/dataFunctions/processData";
 import { unzipFile } from "@/dataFunctions/unzipFile";
 
 const DataUpload = observer(() => {
   const file$ = useObservable<File | null>();
-  const error$ = useObservable<string | null>(null);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (selectedFile) {
       file$.set(selectedFile);
       readFileContent(selectedFile);
-      error$.set(null); // Clear any previous errors
+      resetUiState();
     } else {
       file$.set(null);
       fileContent$.set(null);
-      error$.set("No file selected.");
+      setError("No file selected.");
     }
   };
 
   const readFileContent = async (file: File) => {
+    uiState$.loadingStatus.set("Reading file...");
     const reader = new FileReader();
 
     reader.onload = async (event) => {
       try {
         if (event.target?.result) {
-          const fileExtension = file.name.split('.').pop()?.toLowerCase();
-          if (fileExtension === 'json') {
+          const fileExtension = file.name.split(".").pop()?.toLowerCase();
+          if (fileExtension === "json") {
+            uiState$.loadingStatus.set("Parsing JSON...");
             const jsonContent = JSON.parse(event.target.result as string); // Parse as JSON
             fileContent$.set(jsonContent); // Update state with the parsed JSON object
-          } else if (fileExtension === 'zip') {
-            const zipContent = await unzipFile(new Uint8Array(event.target.result as ArrayBuffer));
+          } else if (fileExtension === "zip") {
+            uiState$.loadingStatus.set("Unzipping...");
+            const zipContent = await unzipFile(
+              new Uint8Array(event.target.result as ArrayBuffer)
+            );
+            uiState$.loadingStatus.set("Extracting JSON files...");
             fileContent$.set(zipContent); // Update state with the extracted JSON object
           } else {
-            error$.set("Unsupported file type.");
+            setError("Unsupported file type.");
             fileContent$.set(null);
           }
         } else {
-          error$.set("File is empty or has no content.");
+          setError("File is empty or has no content.");
           fileContent$.set(null);
         }
       } catch (error) {
         // Catch JSON parsing errors
-        error$.set("Error parsing file: " + (error as Error).message);
+        setError("Error parsing file: " + (error as Error).message);
         fileContent$.set(null);
       }
     };
 
     reader.onerror = () => {
-      error$.set("Error reading file.");
+      setError("Error reading file.");
       fileContent$.set(null);
     };
 
-    if (file.name.endsWith('.json')) {
+    if (file.name.endsWith(".json")) {
       reader.readAsText(file); // Read JSON as text
-    } else if (file.name.endsWith('.zip')) {
+    } else if (file.name.endsWith(".zip")) {
       reader.readAsArrayBuffer(file); // Read ZIP as ArrayBuffer
     } else {
-      error$.set("Unsupported file type.");
+      setError("Unsupported file type.");
       fileContent$.set(null);
     }
   };
@@ -72,6 +77,8 @@ const DataUpload = observer(() => {
   };
 
   const file = file$.get();
+  const loadingString = uiState$.loadingStatus.get();
+  const hasError = uiState$.isError.get();
   return (
     <div className="c-data-upload">
       <h1 className="modal-header">Upload your Spotify data</h1>
@@ -90,8 +97,11 @@ const DataUpload = observer(() => {
         </ul>
         <p>After waiting for a few days, you can now upload the zip!</p>
       </div>
-      {error$.get() && <p style={{ color: "red" }}>{error$.get()}</p>}{" "}
-      {/* Display error messages */}
+      {loadingString && (
+        <p className={`loading-message ${hasError ? "error" : ""}`}>
+          {loadingString}
+        </p>
+      )}
       {file && <p>Selected File: {file.name}</p>}{" "}
       {/* Display selected file name */}
       {fileContent$.get() && (

--- a/src/dataFunctions/unzipFile.ts
+++ b/src/dataFunctions/unzipFile.ts
@@ -1,14 +1,30 @@
-import { unzip, strFromU8 } from 'fflate';
+import { unzip, strFromU8 } from "fflate";
 
 export async function unzipFile(arrayBuffer: Uint8Array): Promise<any> {
-  const unzipped = await unzip(arrayBuffer);
-  const jsonFiles = Object.keys(unzipped).filter(fileName => fileName.endsWith('.json'));
+  const unzipped = await new Promise((resolve, reject) => {
+    unzip(arrayBuffer, (err, unzipped) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(unzipped);
+      }
+    });
+  });
+  if (typeof unzipped !== "object") {
+    throw new Error("Failed to unzip the file.");
+  }
+  if (unzipped === null) {
+    throw new Error("Zip archive is empty?");
+  }
+  const jsonFiles = Object.keys(unzipped).filter((fileName) =>
+    fileName.endsWith(".json")
+  );
 
   if (jsonFiles.length === 0) {
-    throw new Error('No JSON files found in the zip archive.');
+    throw new Error("No JSON files found in the zip archive.");
   }
 
-  const jsonData = jsonFiles.map(fileName => {
+  const jsonData = jsonFiles.map((fileName) => {
     const fileContent = unzipped[fileName];
     return JSON.parse(strFromU8(fileContent));
   });

--- a/src/dataFunctions/unzipFile.ts
+++ b/src/dataFunctions/unzipFile.ts
@@ -1,0 +1,17 @@
+import { unzip, strFromU8 } from 'fflate';
+
+export async function unzipFile(arrayBuffer: Uint8Array): Promise<any> {
+  const unzipped = await unzip(arrayBuffer);
+  const jsonFiles = Object.keys(unzipped).filter(fileName => fileName.endsWith('.json'));
+
+  if (jsonFiles.length === 0) {
+    throw new Error('No JSON files found in the zip archive.');
+  }
+
+  const jsonData = jsonFiles.map(fileName => {
+    const fileContent = unzipped[fileName];
+    return JSON.parse(strFromU8(fileContent));
+  });
+
+  return jsonData;
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,3 +2,27 @@ import { SpotifyStreamingData } from "./types";
 import { observable } from "@legendapp/state";
 export const fileContent$ = observable<SpotifyStreamingData[] | null>(null);
 
+interface UiState {
+  loadingStatus: string | null;
+  isError: boolean;
+  isComplete: boolean;
+}
+
+const initialUiState: UiState = {
+  loadingStatus: null,
+  isError: false,
+  isComplete: false,
+};
+export const uiState$ = observable<UiState>(initialUiState);
+
+export const setError = (error: string) => {
+  uiState$.set({
+    loadingStatus: error,
+    isError: true,
+    isComplete: false,
+  });
+};
+
+export const resetUiState = () => {
+  uiState$.set(initialUiState);
+};


### PR DESCRIPTION
Update file upload code to determine file type and handle both JSON and .zip files.

* Modify `src/components/DataUpload/DataUpload.tsx` to check the file extension and handle JSON and .zip files accordingly.
* Add logic to `readFileContent` function to parse JSON files directly and extract contents from .zip files using the new `unzipFile` function.
* Update error handling to address issues related to both JSON parsing and zip file extraction.
* Create `src/dataFunctions/unzipFile.ts` to handle unzipping of .zip files using fflate.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shanecranor/songskip/pull/3?shareId=1b308977-5030-4188-be12-f66c9ecaccf5).